### PR TITLE
Remove Fahrenheit support; controller is Celsius-only (NZ) 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -225,27 +225,27 @@ propagated.
 toolbar button → `#ortonImportModal` in the UI.
 
 Most kiln-firing recipes are written in *Orton* form:
-"ramp at 200 °/hr to 250 °, hold 30 min, ramp at 400 °/hr to
-1900 °, ramp at 108 °/hr to 2232 °, hold 10 min, fast cool to
-1500 °…". The importer accepts this in JSON form:
+"ramp at 110 °C/hr to 120 °C, hold 30 min, ramp at 220 °C/hr to
+1040 °C, ramp at 60 °C/hr to 1220 °C, hold 10 min, fast cool to
+815 °C…". The importer accepts this in JSON form:
 
 ```json
 {
   "name": "cone-6-glaze",
-  "start_temp": 70,
+  "start_temp": 20,
   "segments": [
-    {"type": "ramp", "rate": 200, "target": 250},
+    {"type": "ramp", "rate": 110, "target": 120},
     {"type": "hold", "minutes": 30},
-    {"type": "ramp", "rate": 400, "target": 1900},
-    {"type": "ramp", "rate": 108, "target": 2232},
+    {"type": "ramp", "rate": 220, "target": 1040},
+    {"type": "ramp", "rate": 60, "target": 1220},
     {"type": "hold", "minutes": 10},
-    {"type": "cool", "rate": 9999, "target": 1500},
-    {"type": "ramp", "rate": 100, "target": 1500}
+    {"type": "cool", "rate": 9999, "target": 815},
+    {"type": "ramp", "rate": 55, "target": 815}
   ]
 }
 ```
 
-`rate` is degrees per **hour** in your `temp_scale`. A rate ≥ 9000
+`rate` is degrees C per **hour**. A rate ≥ 9000
 is treated as "as fast as the kiln can manage" — a near-vertical
 segment in the waypoint output. Use that for cooling segments where
 you want unrestricted radiant cooling.
@@ -447,10 +447,10 @@ drivers, and the MAX31855/MAX31856 + bitbangio modules.
 2. Edit `config.py`:
    * `simulate = True` initially — you should run a full firing in
      simulation before connecting hardware.
-   * `temp_scale`, `kwh_rate`, `kw_elements`, `currency_type`
+   * `kwh_rate`, `kw_elements`, `currency_type`
    * thermocouple pins if you're using software SPI
    * `emergency_shutoff_temp` — set this **below** anything that
-     would melt elements/wiring; for cone 7 firings, 1300 °C / 2400 °F
+     would melt elements/wiring; for cone 7 firings, 1300 °C
      is a reasonable hard stop.
    * leave the new safety features at their defaults to start; tune
      after a successful test firing.

--- a/README.md
+++ b/README.md
@@ -84,12 +84,11 @@ If you're done playing around with simulations and want to deploy the code on a 
 
 ## Configuration
 
-All parameters are defined in config.py. You need to read through config.py carefully to understand each setting. Here are some of the most important settings:
+All parameters are defined in config.py. You need to read through config.py carefully to understand each setting. All temperatures are in degrees Celsius. Here are some of the most important settings:
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | sensor_time_wait | 2 seconds | It's the duty cycle for the entire system.  It's set to two seconds by default which means that a decision is made every 2s about whether to turn on relay[s] and for how long. If you use mechanical relays, you may want to increase this. At 2s, my SSR switches 11,000 times in 13 hours. |
-| temp_scale | f | f for farenheit, c for celcius |
 | pid parameters | | Used to tune your kiln. See PID Tuning. |
 | simulate | True | Simulate a kiln. Used to test the software by new users so they can check out the features. |
  

--- a/config.py
+++ b/config.py
@@ -71,7 +71,7 @@ multiple_thermocouples = False
 # spi_cs_2 is only used when multiple_thermocouples is True.
 # Define it here when adding a second probe (uses the same SPI bus, second CS):
 # spi_cs_2 = board.D6
-multi_tc_delta_alert_degrees = 50  # alert threshold (in temp_scale units)
+multi_tc_delta_alert_degrees = 50  # alert threshold (degrees C)
 
 ########################################################################
 # If your kiln is above the starting temperature of the schedule when you
@@ -98,7 +98,7 @@ pid_kd = 220.83497910261562 # Derivative
 # Derivative spike limiter (#2)
 # Thermocouple noise can produce sudden large derivative-of-error spikes
 # that whip the relay. When True, the dErr value used by the PID is
-# clamped to +/- pid_d_spike_limit (in temp_scale per second) and a
+# clamped to +/- pid_d_spike_limit (degrees C per second) and a
 # small low-pass filter is applied. This prevents noise transients from
 # slamming the SSR while still allowing real heat-up rates through.
 pid_d_spike_limit_enabled = True
@@ -111,12 +111,12 @@ pid_d_filter_alpha = 0.4    # 0..1; higher = more responsive, less smoothing
 stop_integral_windup = True
 
 ########################################################################
-#   Simulation parameters
+#   Simulation parameters (all temperatures in degrees C)
 simulate = False
-sim_t_env      = 65
-sim_c_heat     = 500.0
-sim_c_oven     = 5000.0
-sim_p_heat     = 5450.0
+sim_t_env      = 18         # ambient room temperature (C)
+sim_c_heat     = 900.0      # heater heat capacity (J/C)
+sim_c_oven     = 9000.0     # oven heat capacity (J/C)
+sim_p_heat     = 5450.0     # heater power (W)
 sim_R_o_nocool = 0.5
 sim_R_o_cool   = 0.05
 sim_R_ho_noair = 0.1
@@ -127,7 +127,7 @@ sim_speedup_factor = 1
 #
 #   Time and Temperature parameters
 #
-temp_scale          = "c"  # c = Celsius | f = Fahrenheit
+# All temperatures throughout the controller are in degrees Celsius.
 time_scale_slope    = "h"  # s | m | h - units for displayed slope
 time_scale_profile  = "m"  # s | m | h - units for editing profiles
 
@@ -179,7 +179,7 @@ element_failure_detection = True
 # How long the PID must be above 95% duty before checking heat rate.
 element_failure_min_full_duty_seconds = 240
 # Minimum acceptable heat rate (degrees per hour) at full duty.
-# A typical electric pottery kiln climbs > 200 deg/hr in temp_scale.
+# A typical electric pottery kiln climbs > 200 deg C/hr.
 # Cone 6 cones expect to fire from ~1000C in roughly 2-3hr.
 element_failure_min_heat_rate = 80
 # Below this temperature the kiln may not climb fast (low elements
@@ -191,7 +191,7 @@ element_failure_min_temp = 200
 # After a profile completes the kiln keeps cooling. We track the
 # temperature and notify when it drops below cool_down_safe_open_temp.
 # Set to None to disable the safe-to-open notification.
-cool_down_safe_open_temp = 150       # degrees in temp_scale
+cool_down_safe_open_temp = 150       # degrees C
 cool_down_notify_on_complete = True  # send notification when run completes
 cool_down_notify_on_safe_open = True # send notification at safe_open temp
 

--- a/kiln-controller.py
+++ b/kiln-controller.py
@@ -186,7 +186,7 @@ EDITABLE_CONFIG_KEYS = {
     # economics
     "kwh_rate", "kw_elements", "currency_type",
     # display
-    "temp_scale", "time_scale_slope", "time_scale_profile",
+    "time_scale_slope", "time_scale_profile",
     # safety
     "emergency_shutoff_temp",
     "kiln_must_catch_up",
@@ -383,7 +383,6 @@ def get_config_for_ui():
     """Subset of config served to the read-only UI websocket."""
     return json.dumps(
         {
-            "temp_scale": config.temp_scale,
             "time_scale_slope": config.time_scale_slope,
             "time_scale_profile": config.time_scale_profile,
             "kwh_rate": config.kwh_rate,

--- a/kiln-tuner.py
+++ b/kiln-tuner.py
@@ -185,16 +185,14 @@ def calculate(filename, tangentdivisor, showplot):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Kiln tuner')
     parser.add_argument('-c', '--calculate_only', action='store_true')
-    parser.add_argument('-t', '--target_temp', type=float, default=400, help="Target temperature")
+    parser.add_argument('-t', '--target_temp', type=float, default=200, help="Target temperature in degrees C")
     parser.add_argument('-d', '--tangent_divisor', type=float, default=8, help="Adjust the tangent calculation to fit better. Must be >= 2 (default 8).")
     parser.add_argument('-s', '--showplot', action='store_true', help="draw plot so you can see tanget line and possibly change")
     args = parser.parse_args()
 
     csvfile = "tuning.csv"
     target = args.target_temp
-    if config.temp_scale.lower() == "c":
-        target = (target - 32)*5/9
-    tangentdivisor = args.tangent_divisor 
+    tangentdivisor = args.tangent_divisor
 
     # default behavior is to record profile to csv file tuning.csv
     # and then calculate pid values and print them

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -189,9 +189,7 @@ class TempSensorReal(TempSensor):
 
     def get_temperature(self):
         try:
-            temp = self.raw_temp()  # subclass-provided
-            if config.temp_scale.lower() == "f":
-                temp = (temp * 9 / 5) + 32
+            temp = self.raw_temp()  # subclass-provided, always degrees C
             self.status.good()
             return temp
         except ThermocoupleError as tce:

--- a/public/assets/js/picoreflow.js
+++ b/public/assets/js/picoreflow.js
@@ -6,11 +6,9 @@ var profiles = [];
 var time_mode = 0;
 var selected_profile = 0;
 var selected_profile_name = 'cone-05-long-bisque.json';
-var temp_scale = "c";
 var time_scale_slope = "s";
 var time_scale_profile = "h";
 var time_scale_long = "Seconds";
-var temp_scale_display = "C";
 var kwh_rate = 0.26;
 var currency_type = "EUR";
 
@@ -109,7 +107,7 @@ function updateProfileTable()
     var color = "";
 
     var html = '<h3>Schedule Points</h3><div class="table-responsive" style="scroll: none"><table class="table table-striped">';
-        html += '<tr><th style="width: 50px">#</th><th>Target Time in ' + time_scale_long+ '</th><th>Target Temperature in °'+temp_scale_display+'</th><th>Slope in &deg;'+temp_scale_display+'/'+time_scale_slope+'</th><th></th></tr>';
+        html += '<tr><th style="width: 50px">#</th><th>Target Time in ' + time_scale_long+ '</th><th>Target Temperature in °C</th><th>Slope in &deg;C/'+time_scale_slope+'</th><th></th></tr>';
 
     for(var i=0; i<graph.profile.data.length;i++)
     {
@@ -179,13 +177,7 @@ function formatDPS(val) {
 }
 
 function hazardTemp(){
-
-    if (temp_scale == "f") {
-        return (1500 * 9 / 5) + 32
-    }
-    else {
-        return 1500
-    }
+    return 1500
 }
 
 function timeTickFormatter(val,axis)
@@ -601,18 +593,10 @@ $(document).ready(function()
         {
             console.log (e.data);
             x = JSON.parse(e.data);
-            temp_scale = x.temp_scale;
             time_scale_slope = x.time_scale_slope;
             time_scale_profile = x.time_scale_profile;
             kwh_rate = x.kwh_rate;
             currency_type = x.currency_type;
-
-            if (temp_scale == "c") {temp_scale_display = "C";} else {temp_scale_display = "F";}
-
-
-            $('#act_temp_scale').html('º'+temp_scale_display);
-            $('#target_temp_scale').html('º'+temp_scale_display);
-            $('#heat_rate_temp_scale').html('º'+temp_scale_display);
 
             switch(time_scale_profile){
                 case "s":
@@ -752,7 +736,7 @@ function renderSettings(cfg) {
         ],
         "Cost / display": [
             "kwh_rate", "kw_elements", "currency_type",
-            "temp_scale", "time_scale_slope", "time_scale_profile"
+            "time_scale_slope", "time_scale_profile"
         ],
         "Safety": [
             "emergency_shutoff_temp", "kiln_must_catch_up",

--- a/test-thermocouple.py
+++ b/test-thermocouple.py
@@ -58,17 +58,13 @@ if(config.max31856):
     print("thermocouple: adafruit max31856")
     sensor = adafruit_max31856.MAX31856(spi, cs)
 
-print("Degrees displayed in %s\n" % (config.temp_scale))
+print("Degrees displayed in C\n")
 
 temp = 0
 while(True):
     time.sleep(1)
     try:
         temp = sensor.temperature
-        scale = "C"
-        if config.temp_scale == "f":
-            temp = temp * (9/5) + 32 
-            scale ="F"
-        print("%s %0.2f%s" %(datetime.datetime.now(),temp,scale))
+        print("%s %0.2fC" % (datetime.datetime.now(), temp))
     except Exception as error:
         print("error: " , error)


### PR DESCRIPTION
The temp_scale config knob was unsafe: switching it (e.g. from the web settings modal) updated config server-side but left the live UI labels, profile data, and every numeric threshold (emergency_shutoff_temp, throttle_below_temp, etc.) on the old scale, producing silent unit mismatches mid-firing. Removing the option eliminates the entire bug class.

- Drop temp_scale from config, the web settings modal, EDITABLE_CONFIG_KEYS, the /config websocket payload, and all JS plumbing
- Drop the F-conversion branch in TempSensorReal.get_temperature; thermocouple readings stay in degrees C from the chip
- Convert hardcoded F simulator defaults to C: sim_t_env 65->18, sim_c_heat 500->900, sim_c_oven 5000->9000 (x9/5 to preserve heat rate)
- kiln-tuner.py: drop F->C conversion, change --target_temp default from 400 to 200 (now interpreted as C directly)
- test-thermocouple.py: drop the F branch; always prints C
- Hardcode degrees C in the JS profile table header and simplify hazardTemp() to return 1500
- Update README/CHANGES.md (convert example Orton profile to C values, remove temp_scale row, drop stale F annotations)