### PR TITLE
Switch thermocouple driver from MAX31855 to MAX31856

### DIFF
--- a/config.py
+++ b/config.py
@@ -53,11 +53,10 @@ except (NotImplementedError, AttributeError, ImportError):
 #######################################
 #   max31855 - K type only
 #   max31856 - many thermocouple types
-max31855 = 1
-max31856 = 0
-# Uncomment if using MAX-31856:
-# import adafruit_max31856
-# thermocouple_type = adafruit_max31856.ThermocoupleType.K
+max31855 = 0
+max31856 = 1
+import adafruit_max31856
+thermocouple_type = adafruit_max31856.ThermocoupleType.K
 
 ########################################################################
 # Multiple thermocouple support (#4)
@@ -164,7 +163,7 @@ thermocouple_offset = 0
 temperature_average_samples = 10
 
 # AC frequency rejection for the MAX31856 (50Hz outside North America).
-ac_freq_50hz = False
+ac_freq_50hz = True
 
 ########################################################################
 # Heating-element failure detection (#1)

--- a/test-output.py
+++ b/test-output.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import config
-import adafruit_max31855
 import digitalio
 import time
 import datetime


### PR DESCRIPTION
Hardware swap to the new chips: enable the 31856 driver path with K-type thermocouple, enable 50 Hz noise rejection for NZ mains, and drop the unused 31855 import from test-output.py.